### PR TITLE
Highlight selected addresses on the map

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ streamlit run app.py
 ```
 
 The app will download data from remote URLs when it runs, so an internet connection is required.
+
+After drawing shapes on the map and filtering, the app now displays markers for each
+matching address. Addresses that originally contained a hyphenated unit range are
+shown in **red**, while single addresses appear in **green**. The exported CSV includes
+a new `Hyphenated` column so you can easily identify apartments or condos that were
+expanded from a unit range.


### PR DESCRIPTION

- mark hyphenated unit ranges when parsing addresses
- show filtered addresses on the map with color-coded markers
- add `Hyphenated` column to exported data
- document the new highlighting behavior